### PR TITLE
Feature - Health declaration step

### DIFF
--- a/http/src/main/java/com/aterrizar/http/config/feature/HealthDeclarationProperties.java
+++ b/http/src/main/java/com/aterrizar/http/config/feature/HealthDeclarationProperties.java
@@ -1,27 +1,22 @@
-package com.aterrizar.service.checkin.config;
+package com.aterrizar.http.config.feature;
 
 import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import com.aterrizar.service.checkin.feature.HealthDeclarationCountryChecker;
 import com.neovisionaries.i18n.CountryCode;
 
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 @Configuration
 @Data
 @ConfigurationProperties(prefix = "feature.health.declaration.enabled")
-@NoArgsConstructor
-public class HealthDeclarationProperties {
+public class HealthDeclarationProperties implements HealthDeclarationCountryChecker {
     private List<CountryCode> countries;
 
-    public HealthDeclarationProperties(CountryCode... countries) {
-        this(List.of(countries));
-    }
-
-    public HealthDeclarationProperties(List<CountryCode> countries) {
-        this.countries = countries;
+    public boolean isCountryEnabled(CountryCode countryCode) {
+        return this.countries.contains(countryCode);
     }
 }

--- a/http/src/main/resources/application.properties
+++ b/http/src/main/resources/application.properties
@@ -12,3 +12,5 @@ spring.data.redis.username=default
 spring.data.redis.password=redis
 
 http.client.aviator.base.url=http://localhost:3001/aviator/api/
+
+feature.health.declaration.enabled.countries=CN

--- a/integration/src/main/groovy/com/aterrizar/integration/model/UserInput.groovy
+++ b/integration/src/main/groovy/com/aterrizar/integration/model/UserInput.groovy
@@ -4,7 +4,8 @@ enum UserInput {
     PASSPORT_NUMBER("PASSPORT_NUMBER", "Passport Number"),
     FULL_NAME("FULL_NAME", "Full Name"),
     EMAIL("EMAIL", "Email"),
-    AGREEMENT_SIGNED("AGREEMENT_SIGNED", "Agreement Signed")
+    AGREEMENT_SIGNED("AGREEMENT_SIGNED", "Agreement Signed"),
+    HEALTH_CLEAR_ACKNOWLEDGEMENT("HEALTH_CLEAR_ACKNOWLEDGEMENT", "Health Clear Acknowledgement")
 
     private final String value
     private final String id

--- a/service/src/main/java/com/aterrizar/service/checkin/config/HealthDeclarationProperties.java
+++ b/service/src/main/java/com/aterrizar/service/checkin/config/HealthDeclarationProperties.java
@@ -1,0 +1,27 @@
+package com.aterrizar.service.checkin.config;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import com.neovisionaries.i18n.CountryCode;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Configuration
+@Data
+@ConfigurationProperties(prefix = "feature.health.declaration.enabled")
+@NoArgsConstructor
+public class HealthDeclarationProperties {
+    private List<CountryCode> countries;
+
+    public HealthDeclarationProperties(CountryCode... countries) {
+        this(List.of(countries));
+    }
+
+    public HealthDeclarationProperties(List<CountryCode> countries) {
+        this.countries = countries;
+    }
+}

--- a/service/src/main/java/com/aterrizar/service/checkin/feature/HealthDeclarationCountryChecker.java
+++ b/service/src/main/java/com/aterrizar/service/checkin/feature/HealthDeclarationCountryChecker.java
@@ -1,0 +1,15 @@
+package com.aterrizar.service.checkin.feature;
+
+import java.util.List;
+
+import com.aterrizar.service.core.model.session.FlightData;
+import com.neovisionaries.i18n.CountryCode;
+
+public interface HealthDeclarationCountryChecker {
+    boolean isCountryEnabled(CountryCode countryCode);
+
+    default boolean hasFlightsRequiringHealthDeclaration(List<FlightData> flights) {
+        return flights.stream()
+                .anyMatch(flight -> isCountryEnabled(flight.destination().countryCode()));
+    }
+}

--- a/service/src/main/java/com/aterrizar/service/checkin/flow/GeneralContinueFlow.java
+++ b/service/src/main/java/com/aterrizar/service/checkin/flow/GeneralContinueFlow.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import com.aterrizar.service.checkin.steps.AgreementSignStep;
 import com.aterrizar.service.checkin.steps.CompleteCheckinStep;
 import com.aterrizar.service.checkin.steps.GetSessionStep;
+import com.aterrizar.service.checkin.steps.HealthDeclarationStep;
 import com.aterrizar.service.checkin.steps.PassportInformationStep;
 import com.aterrizar.service.checkin.steps.SaveSessionStep;
 import com.aterrizar.service.checkin.steps.ValidateSessionStep;
@@ -20,6 +21,7 @@ public class GeneralContinueFlow implements FlowStrategy {
     private final ValidateSessionStep validateSessionStep;
     private final PassportInformationStep passportInformationStep;
     private final AgreementSignStep agreementSignStep;
+    private final HealthDeclarationStep healthDeclarationStep;
     private final SaveSessionStep saveSessionStep;
     private final CompleteCheckinStep completeCheckinStep;
 
@@ -30,6 +32,7 @@ public class GeneralContinueFlow implements FlowStrategy {
                 .and(validateSessionStep)
                 .and(passportInformationStep)
                 .and(agreementSignStep)
+                .and(healthDeclarationStep)
                 .and(completeCheckinStep)
                 .andFinally(saveSessionStep);
     }

--- a/service/src/main/java/com/aterrizar/service/checkin/steps/HealthDeclarationStep.java
+++ b/service/src/main/java/com/aterrizar/service/checkin/steps/HealthDeclarationStep.java
@@ -1,0 +1,82 @@
+package com.aterrizar.service.checkin.steps;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.aterrizar.service.checkin.config.HealthDeclarationProperties;
+import com.aterrizar.service.core.framework.flow.Step;
+import com.aterrizar.service.core.framework.flow.StepResult;
+import com.aterrizar.service.core.model.Context;
+import com.aterrizar.service.core.model.RequiredField;
+import com.aterrizar.service.core.model.request.CheckinRequest;
+import com.aterrizar.service.core.model.session.SessionData;
+
+import lombok.AllArgsConstructor;
+
+@Service
+@AllArgsConstructor
+public class HealthDeclarationStep implements Step {
+    private final HealthDeclarationProperties properties;
+
+    @Override
+    public StepResult onExecute(Context context) {
+        if (!isHealthClearAcknowledgementFieldFilled(context)) {
+            var updatedContext = requestHealthClearAcknowledgementField(context);
+            return StepResult.terminal(updatedContext);
+        }
+
+        var updatedContext = captureHealthClearAcknowledgement(context);
+        if (!updatedContext.session().sessionData().healthClearAcknowledgement()) {
+            return StepResult.failure(updatedContext, "Health clear acknowledgement is required");
+        }
+
+        return StepResult.success(updatedContext);
+    }
+
+    @Override
+    public boolean when(Context context) {
+        return hasFlightsRequiringHealthDeclaration(context.session().sessionData());
+    }
+
+    private Context requestHealthClearAcknowledgementField(Context context) {
+        return context.withRequiredField(RequiredField.HEALTH_CLEAR_ACKNOWLEDGEMENT);
+    }
+
+    private Context captureHealthClearAcknowledgement(Context context) {
+        var optionalRequest = Optional.ofNullable(context.checkinRequest());
+
+        return optionalRequest
+                .map(CheckinRequest::providedFields)
+                .map(fields -> fields.get(RequiredField.HEALTH_CLEAR_ACKNOWLEDGEMENT))
+                .map(
+                        healthClearAcknowledgement -> {
+                            var fieldValue = healthClearAcknowledgement.equalsIgnoreCase("true");
+                            return context.withSessionData(
+                                    builder -> builder.healthClearAcknowledgement(fieldValue));
+                        })
+                .orElseThrow(
+                        () ->
+                                new IllegalStateException(
+                                        "Health clear acknowledgement is missing in the request."));
+    }
+
+    private boolean isHealthClearAcknowledgementFieldFilled(Context context) {
+        var optionalRequest = Optional.ofNullable(context.checkinRequest());
+        return optionalRequest.isPresent()
+                && optionalRequest
+                                .get()
+                                .providedFields()
+                                .get(RequiredField.HEALTH_CLEAR_ACKNOWLEDGEMENT)
+                        != null;
+    }
+
+    private boolean hasFlightsRequiringHealthDeclaration(SessionData sessionData) {
+        return sessionData.flights().stream()
+                .anyMatch(
+                        flight ->
+                                properties
+                                        .getCountries()
+                                        .contains(flight.destination().countryCode()));
+    }
+}

--- a/service/src/main/java/com/aterrizar/service/checkin/steps/HealthDeclarationStep.java
+++ b/service/src/main/java/com/aterrizar/service/checkin/steps/HealthDeclarationStep.java
@@ -4,20 +4,19 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
-import com.aterrizar.service.checkin.config.HealthDeclarationProperties;
+import com.aterrizar.service.checkin.feature.HealthDeclarationCountryChecker;
 import com.aterrizar.service.core.framework.flow.Step;
 import com.aterrizar.service.core.framework.flow.StepResult;
 import com.aterrizar.service.core.model.Context;
 import com.aterrizar.service.core.model.RequiredField;
 import com.aterrizar.service.core.model.request.CheckinRequest;
-import com.aterrizar.service.core.model.session.SessionData;
 
 import lombok.AllArgsConstructor;
 
 @Service
 @AllArgsConstructor
 public class HealthDeclarationStep implements Step {
-    private final HealthDeclarationProperties properties;
+    private final HealthDeclarationCountryChecker countryChecker;
 
     @Override
     public StepResult onExecute(Context context) {
@@ -36,7 +35,8 @@ public class HealthDeclarationStep implements Step {
 
     @Override
     public boolean when(Context context) {
-        return hasFlightsRequiringHealthDeclaration(context.session().sessionData());
+        var flights = context.session().sessionData().flights();
+        return countryChecker.hasFlightsRequiringHealthDeclaration(flights);
     }
 
     private Context requestHealthClearAcknowledgementField(Context context) {
@@ -69,14 +69,5 @@ public class HealthDeclarationStep implements Step {
                                 .providedFields()
                                 .get(RequiredField.HEALTH_CLEAR_ACKNOWLEDGEMENT)
                         != null;
-    }
-
-    private boolean hasFlightsRequiringHealthDeclaration(SessionData sessionData) {
-        return sessionData.flights().stream()
-                .anyMatch(
-                        flight ->
-                                properties
-                                        .getCountries()
-                                        .contains(flight.destination().countryCode()));
     }
 }

--- a/service/src/main/java/com/aterrizar/service/core/model/RequiredField.java
+++ b/service/src/main/java/com/aterrizar/service/core/model/RequiredField.java
@@ -7,7 +7,9 @@ public enum RequiredField {
     PASSPORT_NUMBER("PASSPORT_NUMBER", "Passport Number", FieldType.TEXT),
     FULL_NAME("FULL_NAME", "Full Name", FieldType.TEXT),
     EMAIL("EMAIL", "Email", FieldType.EMAIL),
-    AGREEMENT_SIGNED("AGREEMENT_SIGNED", "Agreement Signed", FieldType.BOOLEAN);
+    AGREEMENT_SIGNED("AGREEMENT_SIGNED", "Agreement Signed", FieldType.BOOLEAN),
+    HEALTH_CLEAR_ACKNOWLEDGEMENT(
+            "HEALTH_CLEAR_ACKNOWLEDGEMENT", "Health Clear Acknowledgement", FieldType.BOOLEAN);
 
     private final String value;
     private final String id;

--- a/service/src/main/java/com/aterrizar/service/core/model/session/SessionData.java
+++ b/service/src/main/java/com/aterrizar/service/core/model/session/SessionData.java
@@ -9,5 +9,9 @@ import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record SessionData(
-        CountryCode countryCode, int passengers, boolean agreementSigned, List<FlightData> flights)
+        CountryCode countryCode,
+        int passengers,
+        boolean agreementSigned,
+        boolean healthClearAcknowledgement,
+        List<FlightData> flights)
         implements Serializable {}

--- a/service/src/test/java/com/aterrizar/service/checkin/flow/GeneralContinueFlowTest.java
+++ b/service/src/test/java/com/aterrizar/service/checkin/flow/GeneralContinueFlowTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.aterrizar.service.checkin.steps.AgreementSignStep;
 import com.aterrizar.service.checkin.steps.CompleteCheckinStep;
 import com.aterrizar.service.checkin.steps.GetSessionStep;
+import com.aterrizar.service.checkin.steps.HealthDeclarationStep;
 import com.aterrizar.service.checkin.steps.PassportInformationStep;
 import com.aterrizar.service.checkin.steps.SaveSessionStep;
 import com.aterrizar.service.checkin.steps.ValidateSessionStep;
@@ -27,6 +28,7 @@ class GeneralContinueFlowTest {
     @Mock private ValidateSessionStep validateSessionStep;
     @Mock private PassportInformationStep passportInformationStep;
     @Mock private AgreementSignStep agreementSignStep;
+    @Mock private HealthDeclarationStep healthDeclarationStep;
     @Mock private SaveSessionStep saveSessionStep;
     @Mock private CompleteCheckinStep completeCheckinStep;
     @InjectMocks private GeneralContinueFlow generalContinueFlow;
@@ -37,14 +39,16 @@ class GeneralContinueFlowTest {
         var flowExecutor = new MockFlowExecutor();
         generalContinueFlow.flow(flowExecutor).execute(context);
 
-        assertEquals(5, flowExecutor.getExecutedSteps().size());
-        assertEquals(
+        var validSteps =
                 List.of(
                         "GetSessionStep",
                         "ValidateSessionStep",
                         "PassportInformationStep",
                         "AgreementSignStep",
-                        "CompleteCheckinStep"),
-                flowExecutor.getExecutedSteps());
+                        "HealthDeclarationStep",
+                        "CompleteCheckinStep");
+
+        assertEquals(validSteps.size(), flowExecutor.getExecutedSteps().size());
+        assertEquals(validSteps, flowExecutor.getExecutedSteps());
     }
 }

--- a/service/src/test/java/com/aterrizar/service/checkin/steps/HealthDeclarationStepTest.java
+++ b/service/src/test/java/com/aterrizar/service/checkin/steps/HealthDeclarationStepTest.java
@@ -1,0 +1,149 @@
+package com.aterrizar.service.checkin.steps;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.aterrizar.service.checkin.config.HealthDeclarationProperties;
+import com.aterrizar.service.core.framework.flow.Step;
+import com.aterrizar.service.core.model.Context;
+import com.aterrizar.service.core.model.RequiredField;
+import com.aterrizar.service.core.model.session.Airport;
+import com.aterrizar.service.core.model.session.FlightData;
+import com.neovisionaries.i18n.CountryCode;
+
+import mocks.MockContext;
+
+public class HealthDeclarationStepTest {
+
+    @ParameterizedTest
+    @EnumSource(
+            value = CountryCode.class,
+            names = {"CN", "US", "MX"})
+    void shouldExecuteWhenDestinationIsTargetCountry(CountryCode country) {
+        var healthDeclarationStep = createStepWithTargets(country);
+        var context = createContextWithDestinations(country);
+        var result = healthDeclarationStep.when(context);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void shouldExecuteWhenAnyDestinationIsTargetCountry() {
+        var healthDeclarationStep = createStepWithTargets(CountryCode.ES, CountryCode.US);
+        var context = createContextWithDestinations(CountryCode.MX, CountryCode.CN, CountryCode.US);
+        var result = healthDeclarationStep.when(context);
+
+        assertTrue(result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonTargetCountries")
+    void shouldNotExecuteWhenDestinationsAreNotTargetCountry(
+            CountryCode[] targets, CountryCode[] destinations) {
+
+        var healthDeclarationStep = createStepWithTargets(targets);
+        var context = createContextWithDestinations(destinations);
+        var result = healthDeclarationStep.when(context);
+
+        assertFalse(result);
+    }
+
+    private static Stream<Arguments> nonTargetCountries() {
+        return Stream.of(
+                Arguments.of(
+                        new CountryCode[] {CountryCode.CN, CountryCode.ES},
+                        new CountryCode[] {CountryCode.MX}),
+                Arguments.of(
+                        new CountryCode[] {CountryCode.CN, CountryCode.AU},
+                        new CountryCode[] {CountryCode.US, CountryCode.IN}));
+    }
+
+    @Test
+    void shouldRequestHealthClearAcknowledgementWhenNotProvided() {
+        var healthDeclarationStep = createStepWithTargets(CountryCode.CN);
+        var context = createContextWithDestinations(CountryCode.CN);
+
+        var stepResult = healthDeclarationStep.onExecute(context);
+        var updatedContext = stepResult.context();
+
+        assertTrue(stepResult.isTerminal());
+        assertTrue(stepResult.isSuccess());
+        assertTrue(
+                updatedContext
+                        .checkinResponse()
+                        .providedFields()
+                        .contains(RequiredField.HEALTH_CLEAR_ACKNOWLEDGEMENT));
+    }
+
+    @Test
+    void shouldFailCheckinWhenInvalidHealthClearAcknowledgementProvided() {
+        var healthDeclarationStep = createStepWithTargets(CountryCode.CN);
+        var context =
+                createContextWithDestinations(CountryCode.CN)
+                        .withCheckinRequest(
+                                builder ->
+                                        builder.providedFields(
+                                                Map.of(
+                                                        RequiredField.HEALTH_CLEAR_ACKNOWLEDGEMENT,
+                                                        "false")));
+
+        var stepResult = healthDeclarationStep.onExecute(context);
+
+        assertTrue(stepResult.isTerminal());
+        assertFalse(stepResult.isSuccess());
+    }
+
+    @Test
+    void shouldCaptureHealthClearAcknowledgementFieldWhenProvided() {
+        var healthDeclarationStep = createStepWithTargets(CountryCode.CN);
+        var context =
+                createContextWithDestinations(CountryCode.CN)
+                        .withCheckinRequest(
+                                builder ->
+                                        builder.providedFields(
+                                                Map.of(
+                                                        RequiredField.HEALTH_CLEAR_ACKNOWLEDGEMENT,
+                                                        "true")));
+
+        var stepResult = healthDeclarationStep.onExecute(context);
+        var updatedContext = stepResult.context();
+
+        assertTrue(stepResult.isSuccess());
+        assertFalse(stepResult.isTerminal());
+        assertTrue(updatedContext.session().sessionData().healthClearAcknowledgement());
+    }
+
+    private Step createStepWithTargets(CountryCode... targetCountries) {
+        assertTrue(targetCountries.length > 0, "Target countries should not be empty");
+
+        var properties = new HealthDeclarationProperties(targetCountries);
+        return new HealthDeclarationStep(properties);
+    }
+
+    private Context createContextWithDestinations(CountryCode... destinations) {
+        assertTrue(destinations.length > 0, "Destinations should not be empty");
+
+        var flights =
+                Arrays.stream(destinations)
+                        .map(
+                                code ->
+                                        FlightData.builder()
+                                                .destination(
+                                                        Airport.builder().countryCode(code).build())
+                                                .build())
+                        .toList();
+
+        return MockContext.initializedMock(CountryCode.US)
+                .withSessionData(builder -> builder.flights(flights));
+    }
+}

--- a/service/src/test/java/com/aterrizar/service/checkin/steps/HealthDeclarationStepTest.java
+++ b/service/src/test/java/com/aterrizar/service/checkin/steps/HealthDeclarationStepTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import com.aterrizar.service.checkin.config.HealthDeclarationProperties;
 import com.aterrizar.service.core.framework.flow.Step;
 import com.aterrizar.service.core.model.Context;
 import com.aterrizar.service.core.model.RequiredField;
@@ -21,6 +20,7 @@ import com.aterrizar.service.core.model.session.Airport;
 import com.aterrizar.service.core.model.session.FlightData;
 import com.neovisionaries.i18n.CountryCode;
 
+import mocks.HealthDeclarationCountryCheckerMock;
 import mocks.MockContext;
 
 public class HealthDeclarationStepTest {
@@ -126,7 +126,7 @@ public class HealthDeclarationStepTest {
     private Step createStepWithTargets(CountryCode... targetCountries) {
         assertTrue(targetCountries.length > 0, "Target countries should not be empty");
 
-        var properties = new HealthDeclarationProperties(targetCountries);
+        var properties = new HealthDeclarationCountryCheckerMock(targetCountries);
         return new HealthDeclarationStep(properties);
     }
 

--- a/service/src/test/java/mocks/HealthDeclarationCountryCheckerMock.java
+++ b/service/src/test/java/mocks/HealthDeclarationCountryCheckerMock.java
@@ -1,0 +1,22 @@
+package mocks;
+
+import java.util.List;
+
+import com.aterrizar.service.checkin.feature.HealthDeclarationCountryChecker;
+import com.neovisionaries.i18n.CountryCode;
+
+public class HealthDeclarationCountryCheckerMock implements HealthDeclarationCountryChecker {
+    private final List<CountryCode> countries;
+
+    public HealthDeclarationCountryCheckerMock(CountryCode... countries) {
+        this(List.of(countries));
+    }
+
+    public HealthDeclarationCountryCheckerMock(List<CountryCode> countries) {
+        this.countries = countries;
+    }
+
+    public boolean isCountryEnabled(CountryCode countryCode) {
+        return this.countries.contains(countryCode);
+    }
+}


### PR DESCRIPTION
### Description
Added a health declaration step (to the general continue flow), to comply with flight regulations by the OHMS, which requires
that all passengers traveling through China must sign a sworn agreement confirming they have been vaccinated against Red Fever.

### Technical Details
- **Module Affected**
  - Http: application.properties
  - Service: feature & unit tests
  - Integration: integrations tests
- **Key Changes**:
  - Added a `feature.health.declaration.enabled.countries` property, allows to set the countries (by code) that require this
  - Added a `HEALTH_CLEAR_ACKNOWLEDGEMENT` field in `RequiredField`, `SessionData` & `UserInput`
  - Added the step to the valid steps of the General continue flow test
  - Added unit and integration tests for the feature
