### PR TITLE
feat: implement composite step pattern for session management (CHK-21)

### DIFF
--- a/service/src/main/java/com/aterrizar/service/checkin/flow/GeneralContinueFlow.java
+++ b/service/src/main/java/com/aterrizar/service/checkin/flow/GeneralContinueFlow.java
@@ -5,10 +5,9 @@ import org.springframework.stereotype.Service;
 import com.aterrizar.service.checkin.steps.AgreementSignStep;
 import com.aterrizar.service.checkin.steps.CompleteCheckinStep;
 import com.aterrizar.service.checkin.steps.DigitalVisaValidationStep;
-import com.aterrizar.service.checkin.steps.GetSessionStep;
+import com.aterrizar.service.checkin.steps.InitSessionCompositeStep;
 import com.aterrizar.service.checkin.steps.PassportInformationStep;
 import com.aterrizar.service.checkin.steps.SaveSessionStep;
-import com.aterrizar.service.checkin.steps.ValidateSessionStep;
 import com.aterrizar.service.core.framework.flow.FlowExecutor;
 import com.aterrizar.service.core.framework.flow.FlowStrategy;
 import com.aterrizar.service.core.model.ExperimentalStepKey;
@@ -18,19 +17,17 @@ import lombok.AllArgsConstructor;
 @Service
 @AllArgsConstructor
 public class GeneralContinueFlow implements FlowStrategy {
-    private final GetSessionStep getSessionStep;
-    private final ValidateSessionStep validateSessionStep;
     private final PassportInformationStep passportInformationStep;
     private final AgreementSignStep agreementSignStep;
     private final SaveSessionStep saveSessionStep;
     private final CompleteCheckinStep completeCheckinStep;
     private final DigitalVisaValidationStep digitalVisaValidationStep;
+    private final InitSessionCompositeStep initSessionCompositeStep;
 
     @Override
     public FlowExecutor flow(FlowExecutor baseExecutor) {
         return baseExecutor
-                .and(getSessionStep)
-                .and(validateSessionStep)
+                .and(initSessionCompositeStep)
                 .and(passportInformationStep)
                 .and(digitalVisaValidationStep)
                 .andExperimental(agreementSignStep, ExperimentalStepKey.AGREEMENT_SIGN)

--- a/service/src/main/java/com/aterrizar/service/checkin/flow/VeContinueFlow.java
+++ b/service/src/main/java/com/aterrizar/service/checkin/flow/VeContinueFlow.java
@@ -5,10 +5,9 @@ import org.springframework.stereotype.Service;
 import com.aterrizar.service.checkin.steps.AgreementSignStep;
 import com.aterrizar.service.checkin.steps.CompleteCheckinStep;
 import com.aterrizar.service.checkin.steps.FundsCheckStep;
-import com.aterrizar.service.checkin.steps.GetSessionStep;
+import com.aterrizar.service.checkin.steps.InitSessionCompositeStep;
 import com.aterrizar.service.checkin.steps.PassportInformationStep;
 import com.aterrizar.service.checkin.steps.SaveSessionStep;
-import com.aterrizar.service.checkin.steps.ValidateSessionStep;
 import com.aterrizar.service.core.framework.flow.FlowExecutor;
 import com.aterrizar.service.core.framework.flow.FlowStrategy;
 
@@ -17,19 +16,17 @@ import lombok.AllArgsConstructor;
 @Service
 @AllArgsConstructor
 public class VeContinueFlow implements FlowStrategy {
-    private final GetSessionStep getSessionStep;
-    private final ValidateSessionStep validateSessionStep;
     private final PassportInformationStep passportInformationStep;
     private final AgreementSignStep agreementSignStep;
     private final SaveSessionStep saveSessionStep;
     private final CompleteCheckinStep completeCheckinStep;
     private final FundsCheckStep fundsCheckStep;
+    private final InitSessionCompositeStep initSessionCompositeStep;
 
     @Override
     public FlowExecutor flow(FlowExecutor baseExecutor) {
         return baseExecutor
-                .and(getSessionStep)
-                .and(validateSessionStep)
+                .and(initSessionCompositeStep)
                 .and(fundsCheckStep)
                 .and(passportInformationStep)
                 .and(agreementSignStep)

--- a/service/src/main/java/com/aterrizar/service/checkin/steps/InitSessionCompositeStep.java
+++ b/service/src/main/java/com/aterrizar/service/checkin/steps/InitSessionCompositeStep.java
@@ -1,0 +1,21 @@
+package com.aterrizar.service.checkin.steps;
+
+import org.springframework.stereotype.Service;
+
+import com.aterrizar.service.core.framework.flow.CompositeStep;
+import com.aterrizar.service.core.framework.flow.FlowExecutor;
+
+import lombok.AllArgsConstructor;
+
+@Service
+@AllArgsConstructor
+public class InitSessionCompositeStep extends CompositeStep {
+
+    private final GetSessionStep getSessionStep;
+    private final ValidateSessionStep validateSessionStep;
+
+    @Override
+    protected FlowExecutor registerSteps(FlowExecutor executor) {
+        return executor.and(getSessionStep).and(validateSessionStep);
+    }
+}

--- a/service/src/main/java/com/aterrizar/service/core/framework/flow/CompositeStep.java
+++ b/service/src/main/java/com/aterrizar/service/core/framework/flow/CompositeStep.java
@@ -1,7 +1,6 @@
 package com.aterrizar.service.core.framework.flow;
 
 import com.aterrizar.service.core.model.Context;
-import com.aterrizar.service.core.model.session.Status;
 
 public abstract class CompositeStep implements Step {
     protected abstract FlowExecutor registerSteps(FlowExecutor executor);
@@ -9,12 +8,6 @@ public abstract class CompositeStep implements Step {
     @Override
     public StepResult onExecute(Context context) {
         var executor = registerSteps(new FlowExecutor());
-        var resultContext = executor.execute(context);
-
-        if (resultContext.session() != null && Status.REJECTED.equals(resultContext.status())) {
-            return StepResult.terminal(resultContext);
-        }
-
-        return StepResult.success(resultContext);
+        return executor.executeWithResult(context);
     }
 }

--- a/service/src/main/java/com/aterrizar/service/core/framework/flow/CompositeStep.java
+++ b/service/src/main/java/com/aterrizar/service/core/framework/flow/CompositeStep.java
@@ -1,0 +1,20 @@
+package com.aterrizar.service.core.framework.flow;
+
+import com.aterrizar.service.core.model.Context;
+import com.aterrizar.service.core.model.session.Status;
+
+public abstract class CompositeStep implements Step {
+    protected abstract FlowExecutor registerSteps(FlowExecutor executor);
+
+    @Override
+    public StepResult onExecute(Context context) {
+        var executor = registerSteps(new FlowExecutor());
+        var resultContext = executor.execute(context);
+
+        if (resultContext.session() != null && Status.REJECTED.equals(resultContext.status())) {
+            return StepResult.terminal(resultContext);
+        }
+
+        return StepResult.success(resultContext);
+    }
+}

--- a/service/src/main/java/com/aterrizar/service/core/framework/flow/FlowExecutor.java
+++ b/service/src/main/java/com/aterrizar/service/core/framework/flow/FlowExecutor.java
@@ -75,6 +75,10 @@ public class FlowExecutor {
      * @return the updated `Context` after processing all applicable steps
      */
     public Context execute(Context context) {
+        return executeWithResult(context).context();
+    }
+
+    public StepResult executeWithResult(Context context) {
         var updatedContext = context;
         for (Step step : this.steps) {
             var stepResult = step.execute(updatedContext);
@@ -89,11 +93,11 @@ public class FlowExecutor {
                                 .withCheckinResponse(
                                         responseBuilder ->
                                                 responseBuilder.errorMessage(stepResult.message()));
-                break;
+                return StepResult.terminal(updatedContext);
             }
 
             if (stepResult.isTerminal()) {
-                break;
+                return StepResult.terminal(updatedContext);
             }
         }
 
@@ -101,6 +105,6 @@ public class FlowExecutor {
             var stepResult = this.lastStep.execute(updatedContext);
             updatedContext = stepResult.context();
         }
-        return updatedContext;
+        return StepResult.success(updatedContext);
     }
 }

--- a/service/src/test/java/com/aterrizar/service/checkin/flow/GeneralContinueFlowTest.java
+++ b/service/src/test/java/com/aterrizar/service/checkin/flow/GeneralContinueFlowTest.java
@@ -14,10 +14,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.aterrizar.service.checkin.steps.AgreementSignStep;
 import com.aterrizar.service.checkin.steps.CompleteCheckinStep;
 import com.aterrizar.service.checkin.steps.DigitalVisaValidationStep;
-import com.aterrizar.service.checkin.steps.GetSessionStep;
+import com.aterrizar.service.checkin.steps.InitSessionCompositeStep;
 import com.aterrizar.service.checkin.steps.PassportInformationStep;
 import com.aterrizar.service.checkin.steps.SaveSessionStep;
-import com.aterrizar.service.checkin.steps.ValidateSessionStep;
 import com.aterrizar.service.core.model.ExperimentalStepKey;
 import com.aterrizar.service.core.model.session.ExperimentalData;
 import com.neovisionaries.i18n.CountryCode;
@@ -27,8 +26,7 @@ import mocks.MockFlowExecutor;
 
 @ExtendWith(MockitoExtension.class)
 class GeneralContinueFlowTest {
-    @Mock private GetSessionStep getSessionStep;
-    @Mock private ValidateSessionStep validateSessionStep;
+    @Mock private InitSessionCompositeStep initSessionCompositeStep;
     @Mock private PassportInformationStep passportInformationStep;
     @Mock private AgreementSignStep agreementSignStep;
     @Mock private SaveSessionStep saveSessionStep;
@@ -52,8 +50,7 @@ class GeneralContinueFlowTest {
 
         var expectedSteps =
                 List.of(
-                        "GetSessionStep",
-                        "ValidateSessionStep",
+                        "InitSessionCompositeStep",
                         "PassportInformationStep",
                         "DigitalVisaValidationStep",
                         "AgreementSignStep",
@@ -70,8 +67,7 @@ class GeneralContinueFlowTest {
 
         var expectedSteps =
                 List.of(
-                        "GetSessionStep",
-                        "ValidateSessionStep",
+                        "InitSessionCompositeStep",
                         "PassportInformationStep",
                         "DigitalVisaValidationStep",
                         "CompleteCheckinStep");

--- a/service/src/test/java/com/aterrizar/service/checkin/flow/VeContinueFlowTest.java
+++ b/service/src/test/java/com/aterrizar/service/checkin/flow/VeContinueFlowTest.java
@@ -13,10 +13,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.aterrizar.service.checkin.steps.AgreementSignStep;
 import com.aterrizar.service.checkin.steps.CompleteCheckinStep;
 import com.aterrizar.service.checkin.steps.FundsCheckStep;
-import com.aterrizar.service.checkin.steps.GetSessionStep;
+import com.aterrizar.service.checkin.steps.InitSessionCompositeStep;
 import com.aterrizar.service.checkin.steps.PassportInformationStep;
 import com.aterrizar.service.checkin.steps.SaveSessionStep;
-import com.aterrizar.service.checkin.steps.ValidateSessionStep;
 import com.neovisionaries.i18n.CountryCode;
 
 import mocks.MockContext;
@@ -24,8 +23,7 @@ import mocks.MockFlowExecutor;
 
 @ExtendWith(MockitoExtension.class)
 public class VeContinueFlowTest {
-    @Mock private GetSessionStep getSessionStep;
-    @Mock private ValidateSessionStep validateSessionStep;
+    @Mock private InitSessionCompositeStep initSessionCompositeStep;
     @Mock private FundsCheckStep fundsCheckStep;
     @Mock private PassportInformationStep passportInformationStep;
     @Mock private AgreementSignStep agreementSignStep;
@@ -40,11 +38,10 @@ public class VeContinueFlowTest {
         var flowExecutor = new MockFlowExecutor();
         veContinueFlow.flow(flowExecutor).execute(context);
 
-        assertEquals(6, flowExecutor.getExecutedSteps().size());
+        assertEquals(5, flowExecutor.getExecutedSteps().size());
         assertEquals(
                 List.of(
-                        "GetSessionStep",
-                        "ValidateSessionStep",
+                        "InitSessionCompositeStep",
                         "FundsCheckStep",
                         "PassportInformationStep",
                         "AgreementSignStep",

--- a/service/src/test/java/com/aterrizar/service/checkin/steps/CompositeStepTest.java
+++ b/service/src/test/java/com/aterrizar/service/checkin/steps/CompositeStepTest.java
@@ -1,0 +1,93 @@
+package com.aterrizar.service.checkin.steps;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+import com.aterrizar.service.core.framework.flow.CompositeStep;
+import com.aterrizar.service.core.framework.flow.FlowExecutor;
+import com.aterrizar.service.core.framework.flow.Step;
+import com.aterrizar.service.core.framework.flow.StepResult;
+import com.aterrizar.service.core.model.session.Status;
+import com.neovisionaries.i18n.CountryCode;
+
+import mocks.MockContext;
+
+class CompositeStepTest {
+
+    @Test
+    void shouldExecuteSubStepsAndReturnSuccess() {
+        var context = MockContext.initializedMock(CountryCode.US);
+        var step1 = mock(Step.class);
+        var step2 = mock(Step.class);
+        when(step1.when(any())).thenReturn(true);
+        when(step2.when(any())).thenReturn(true);
+        when(step1.execute(any())).thenReturn(StepResult.success(context));
+        when(step2.execute(any())).thenReturn(StepResult.success(context));
+
+        var composite =
+                new CompositeStep() {
+                    @Override
+                    protected FlowExecutor registerSteps(FlowExecutor executor) {
+                        return executor.and(step1).and(step2);
+                    }
+                };
+
+        var result = composite.onExecute(context);
+
+        assertTrue(result.isSuccess());
+        assertFalse(result.isTerminal());
+    }
+
+    @Test
+    void shouldReturnTerminalWhenSubStepFails() {
+        var context = MockContext.initializedMock(CountryCode.US);
+        var failingStep = mock(Step.class);
+        when(failingStep.when(any())).thenReturn(true);
+        when(failingStep.execute(any()))
+                .thenReturn(StepResult.failure(context, "Session not found"));
+
+        var composite =
+                new CompositeStep() {
+                    @Override
+                    protected FlowExecutor registerSteps(FlowExecutor executor) {
+                        return executor.and(failingStep);
+                    }
+                };
+
+        var result = composite.onExecute(context);
+
+        assertTrue(result.isTerminal());
+        assertEquals(Status.REJECTED, result.context().status());
+        assertNull(result.message());
+    }
+
+    @Test
+    void shouldNotExecuteNextSubStepAfterFailure() {
+        var context = MockContext.initializedMock(CountryCode.US);
+        var failingStep = mock(Step.class);
+        var nextStep = mock(Step.class);
+        when(failingStep.when(any())).thenReturn(true);
+        when(failingStep.execute(any())).thenReturn(StepResult.failure(context, "error"));
+
+        var composite =
+                new CompositeStep() {
+                    @Override
+                    protected FlowExecutor registerSteps(FlowExecutor executor) {
+                        return executor.and(failingStep).and(nextStep);
+                    }
+                };
+
+        composite.onExecute(context);
+
+        verify(nextStep, never()).execute(any());
+    }
+}

--- a/service/src/test/java/com/aterrizar/service/checkin/steps/InitSessionCompositeStepTest.java
+++ b/service/src/test/java/com/aterrizar/service/checkin/steps/InitSessionCompositeStepTest.java
@@ -1,0 +1,38 @@
+package com.aterrizar.service.checkin.steps;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.aterrizar.service.core.framework.flow.StepResult;
+import com.neovisionaries.i18n.CountryCode;
+
+import mocks.MockContext;
+
+@ExtendWith(MockitoExtension.class)
+class InitSessionCompositeStepTest {
+
+    @Mock private GetSessionStep getSessionStep;
+    @Mock private ValidateSessionStep validateSessionStep;
+    @InjectMocks private InitSessionCompositeStep initSessionCompositeStep;
+
+    @Test
+    void shouldExecuteGetSessionAndValidateSessionStepsInOrder() {
+        var context = MockContext.initializedMock(CountryCode.US);
+
+        when(getSessionStep.execute(any())).thenReturn(StepResult.success(context));
+        when(validateSessionStep.execute(any())).thenReturn(StepResult.success(context));
+
+        initSessionCompositeStep.onExecute(context);
+
+        var order = inOrder(getSessionStep, validateSessionStep);
+        order.verify(getSessionStep).execute(any());
+        order.verify(validateSessionStep).execute(any());
+    }
+}


### PR DESCRIPTION
### Add Composite Step pattern to support macro-steps in flow strategies

Introduces `CompositeStep`, an abstract class that allows grouping related steps into a single semantic unit using an internal `FlowExecutor`. Implements `InitSessionCompositeStep` as the first concrete use case, compounding `GetSessionStep` and `ValidateSessionStep`. Flow strategies are updated to use this new structure, keeping the main flow chain clean and readable.